### PR TITLE
Add better Azure DevOps CI definitions

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -1,0 +1,39 @@
+pool:
+  vmImage: 'Ubuntu 16.04'
+
+trigger:
+- master
+
+pr:
+- master
+
+variables:
+  buildConfiguration: 'Release'
+
+steps:
+- task: DotNetCoreCLI@2
+  displayName: Restore
+  inputs:
+    command: 'restore'
+    projects: 'src/*.csproj'
+
+- task: DotNetCoreCLI@2
+  displayName: Build
+  inputs:    
+    command: 'build'
+    projects: 'src/*.csproj'
+    arguments: '--configuration $(BuildConfiguration)'
+
+- task: DotNetCoreCLI@2
+  displayName: Test
+  inputs:
+    command: 'test'
+    projects: 'test/*.csproj'
+    arguments: '--collect:"XPlat Code Coverage"'
+
+- task: PublishCodeCoverageResults@1
+  inputs:
+    codeCoverageTool: 'Cobertura'
+    summaryFileLocation: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
+    pathToSources: 'src/'
+    reportDirectory: 'report/'

--- a/azure-pipelines-tag.yml
+++ b/azure-pipelines-tag.yml
@@ -1,0 +1,50 @@
+trigger:
+  tags:
+    include:
+      - v*
+
+pool:
+  vmImage: 'Ubuntu 16.04'
+
+variables:
+  buildConfiguration: 'Release'
+
+steps:
+- task: GitVersion@5
+  inputs:
+    runtime: 'core'
+
+- task: DotNetCoreCLI@2
+  displayName: Restore
+  inputs:
+    command: 'restore'
+    projects: 'src/*.csproj'
+
+- task: DotNetCoreCLI@2  
+  inputs:
+    command: 'build'
+    projects: 'src/*.csproj'
+    arguments: '--configuration $(buildConfiguration) /p:Version=$(GitVersion.SemVer) /p:InformationalVersion=$(GitVersion.FullSemVer)'
+  displayName: 'dotnet build $(buildConfiguration)'
+
+- task: DotNetCoreCLI@2
+  displayName: Test
+  inputs:
+    command: 'test'
+    projects: 'test/*.csproj'
+    arguments: '--collect:"XPlat Code Coverage"'
+
+- task: PublishCodeCoverageResults@1
+  inputs:
+    codeCoverageTool: 'Cobertura'
+    summaryFileLocation: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
+    pathToSources: 'src/'
+    reportDirectory: 'report/'
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet pack'
+  inputs:
+    command: pack
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: drop'

--- a/test/Ktos.AspNetCore.Authentication.ApiKeyHeader.Tests.csproj
+++ b/test/Ktos.AspNetCore.Authentication.ApiKeyHeader.Tests.csproj
@@ -15,6 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add proper Azure DevOps CI on pull requests and on tags, testing, publishing test results and preparing final package using GitVersionTask.