### PR TITLE
Add support for custom logic of handling API keys

### DIFF
--- a/Ktos.AspNetCore.Authentication.ApiKey.sln
+++ b/Ktos.AspNetCore.Authentication.ApiKey.sln
@@ -7,8 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ktos.AspNetCore.Authenticat
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ktos.AspNetCore.Authentication.ApiKeyHeader.Tests", "test\Ktos.AspNetCore.Authentication.ApiKeyHeader.Tests.csproj", "{445D7161-C28F-44CA-87A4-EA393575506E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApplication1", "WebApplication1\WebApplication1.csproj", "{833DEFDA-3ABD-4195-83B8-B7A73D0270C1}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,10 +21,6 @@ Global
 		{445D7161-C28F-44CA-87A4-EA393575506E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{445D7161-C28F-44CA-87A4-EA393575506E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{445D7161-C28F-44CA-87A4-EA393575506E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{833DEFDA-3ABD-4195-83B8-B7A73D0270C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{833DEFDA-3ABD-4195-83B8-B7A73D0270C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{833DEFDA-3ABD-4195-83B8-B7A73D0270C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{833DEFDA-3ABD-4195-83B8-B7A73D0270C1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Ktos.AspNetCore.Authentication.ApiKey.sln
+++ b/Ktos.AspNetCore.Authentication.ApiKey.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.168
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29920.165
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ktos.AspNetCore.Authentication.ApiKeyHeader", "src\Ktos.AspNetCore.Authentication.ApiKeyHeader.csproj", "{6E853B99-F93D-402E-83F4-E49ACB8AA746}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ktos.AspNetCore.Authentication.ApiKeyHeader.Tests", "test\Ktos.AspNetCore.Authentication.ApiKeyHeader.Tests.csproj", "{445D7161-C28F-44CA-87A4-EA393575506E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApplication1", "WebApplication1\WebApplication1.csproj", "{833DEFDA-3ABD-4195-83B8-B7A73D0270C1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{445D7161-C28F-44CA-87A4-EA393575506E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{445D7161-C28F-44CA-87A4-EA393575506E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{445D7161-C28F-44CA-87A4-EA393575506E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{833DEFDA-3ABD-4195-83B8-B7A73D0270C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{833DEFDA-3ABD-4195-83B8-B7A73D0270C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{833DEFDA-3ABD-4195-83B8-B7A73D0270C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{833DEFDA-3ABD-4195-83B8-B7A73D0270C1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ public void ConfigureServices(IServiceCollection services)
         options.DefaultAuthenticateScheme = ApiKeyHeaderAuthenticationDefaults.AuthenticationScheme;
         options.DefaultChallengeScheme = ApiKeyHeaderAuthenticationDefaults.AuthenticationScheme;
     })
-        .AddApiKeyHeaderAuthentication(options => { options.ApiKey = "my-secret-api-key"; options.Header = "x-api-key"; );
+        .AddApiKeyHeaderAuthentication(options => { options.ApiKey = "my-secret-api-key"; options.Header = "x-api-key"; });
 
     // ...
 }

--- a/src/ApiKeyHeaderAuthenticationExtensions.cs
+++ b/src/ApiKeyHeaderAuthenticationExtensions.cs
@@ -41,6 +41,14 @@ using System.Threading.Tasks;
 namespace Ktos.AspNetCore.Authentication.ApiKeyHeader
 {
     /// <summary>
+    /// Function returning if provided API key is valid or not
+    /// </summary>
+    /// <param name="apiKey">API key sent along with HTTP request</param>
+    /// <returns>Pair of bool, string, where bool defines if API key was valid and string
+    /// will be used as principal name in provided claims</returns>
+    public delegate (bool, string) CustomApiKeyHandlerDelegate(string apiKey);
+
+    /// <summary>
     /// Some defaults for the ApiKey Header Authentication schemea
     /// </summary>
     public static class ApiKeyHeaderAuthenticationDefaults
@@ -89,7 +97,7 @@ namespace Ktos.AspNetCore.Authentication.ApiKeyHeader
         /// ticket and result of the authentication. May be used for checking multiple authentication keys
         /// for multiple users or for adding custom logic along with authentication, like additional logging.
         /// </para>
-        Func<string, (string, bool)> CustomAuthenticationHandler { get; }
+        CustomApiKeyHandlerDelegate CustomAuthenticationHandler { get; }
     }
 
     /// <summary>
@@ -118,7 +126,7 @@ namespace Ktos.AspNetCore.Authentication.ApiKeyHeader
         /// logic is fired.
         /// </para>
         /// </summary>
-        public Func<string, (string, bool)> CustomAuthenticationHandler { get; set; }
+        public CustomApiKeyHandlerDelegate CustomAuthenticationHandler { get; set; }
 
         /// <summary>
         /// Defines a custom authentication type implementing IApiKeyCustomAuthenticator which will be accessed
@@ -162,7 +170,7 @@ namespace Ktos.AspNetCore.Authentication.ApiKeyHeader
                     throw new InvalidCastException("Failed to use provided custom authenticator type as IApiKeyCustomAuthenticator");
                 }
 
-                (var claimName, var result) = service.CustomAuthenticationHandler(headerKey);
+                (var result, var claimName) = service.CustomAuthenticationHandler(headerKey);
                 if (result)
                 {
                     return AuthenticateResult.Success(CreateAuthenticationTicket(claimName));
@@ -174,7 +182,7 @@ namespace Ktos.AspNetCore.Authentication.ApiKeyHeader
             }
             else if (Options.CustomAuthenticationHandler != null)
             {
-                (var claimName, var result) = Options.CustomAuthenticationHandler(headerKey);
+                (var result, var claimName) = Options.CustomAuthenticationHandler(headerKey);
                 if (result)
                 {
                     return AuthenticateResult.Success(CreateAuthenticationTicket(claimName));

--- a/test/Ktos.AspNetCore.Authentication.ApiKeyHeader.Tests.csproj
+++ b/test/Ktos.AspNetCore.Authentication.ApiKeyHeader.Tests.csproj
@@ -15,7 +15,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="coverlet.collector" Version="1.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestBed.cs
+++ b/test/TestBed.cs
@@ -35,6 +35,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Net.Http;
 
@@ -44,6 +45,11 @@ namespace Ktos.AspNetCore.Authentication.ApiKeyHeader.Tests
 {
     internal class TestApiKeyService : IApiKeyCustomAuthenticator
     {
+        public TestApiKeyService(ILogger<TestApiKeyService> logging)
+        {
+            logging.LogInformation("Created a test authenticator");
+        }
+
         // returns true on "testapi", returns uppercase key as name, false in any other case
         public CustomApiKeyHandlerDelegate CustomAuthenticationHandler => (key) => key == "testapi" ? (true, key.ToUpper()) : (false, null);
     }

--- a/test/TestBed.cs
+++ b/test/TestBed.cs
@@ -42,6 +42,12 @@ using System.Net.Http;
 
 namespace Ktos.AspNetCore.Authentication.ApiKeyHeader.Tests
 {
+    internal class TestApiKeyService : IApiKeyCustomAuthenticator
+    {
+        // returns true on "testapi", returns uppercase key as name, false in any other case
+        public CustomApiKeyHandlerDelegate CustomAuthenticationHandler => (key) => key == "testapi" ? (true, key.ToUpper()) : (false, null);
+    }
+
     internal static class TestBed
     {
         public static void SetApiKey(this HttpClient client, string apikey, string header = ApiKeyHeaderAuthenticationDefaults.AuthenticationHeader)
@@ -94,6 +100,9 @@ namespace Ktos.AspNetCore.Authentication.ApiKeyHeader.Tests
                 .ConfigureServices(services =>
                 {
                     builderAction(services.AddAuthentication(ApiKeyHeaderAuthenticationDefaults.AuthenticationScheme));
+
+                    // add singleton class used for custom authentication
+                    services.AddSingleton<TestApiKeyService>();
                 });
 
             return new TestServer(builder);

--- a/test/TestBed.cs
+++ b/test/TestBed.cs
@@ -46,6 +46,7 @@ namespace Ktos.AspNetCore.Authentication.ApiKeyHeader.Tests
     {
         public static void SetApiKey(this HttpClient client, string apikey, string header = ApiKeyHeaderAuthenticationDefaults.AuthenticationHeader)
         {
+            client.DefaultRequestHeaders.Clear();
             client.DefaultRequestHeaders.Add(header, apikey);
         }
 
@@ -76,7 +77,13 @@ namespace Ktos.AspNetCore.Authentication.ApiKeyHeader.Tests
                         {
                             var result = await context.AuthenticateAsync(ApiKeyHeaderAuthenticationDefaults.AuthenticationScheme);
                             if (!result.Succeeded)
+                            {
                                 await context.ChallengeAsync(ApiKeyHeaderAuthenticationDefaults.AuthenticationScheme);
+                            }
+                            else
+                            {
+                                await context.Response.WriteAsync(result.Ticket.Principal.Identity.Name);
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
Adds a support for simple custom logic in form of a function being run instead of checking if API key provided in the request is equal to the key defined in options.

In more advanced case, the custom logic type is being used, which may be created for example as singleton service for the dependency injection framework, allowing for more complex logic, using databases, checking keys quota and so on.